### PR TITLE
Fix inotify related bugs and events specification

### DIFF
--- a/include/x-watcher/x-watcher.h
+++ b/include/x-watcher/x-watcher.h
@@ -174,12 +174,9 @@ typedef struct x_watcher {
 
 				if(event->mask & IN_CREATE)
 					send_event = XWATCHER_FILE_CREATED;
-				if(event->mask & IN_MODIFY)
+				if(event->mask & IN_CLOSE_WRITE)
 					send_event = XWATCHER_FILE_MODIFIED;
-				if(event->mask & IN_DELETE)
-					send_event = XWATCHER_FILE_REMOVED;
-				if(event->mask & IN_CLOSE_WRITE ||
-						event->mask & IN_CLOSE_NOWRITE)
+				if(event->mask & IN_DELETE_SELF)
 					send_event = XWATCHER_FILE_REMOVED;
 				if(event->mask & IN_ATTRIB)
 					send_event = XWATCHER_FILE_ATTRIBUTES_CHANGED;

--- a/include/x-watcher/x-watcher.h
+++ b/include/x-watcher/x-watcher.h
@@ -26,6 +26,7 @@ typedef enum event {
 	XWATCHER_FILE_RENAMED,
 
 	// directory specific events
+	XWATCHER_DIRECTORY_CONTENT_CRETAED,
 	XWATCHER_DIRECTORY_CONTENT_REMOVED,
 	XWATCHER_DIRECTORY_CONTENT_MOVED,
 } XWATCHER_FILE_EVENT;
@@ -176,22 +177,22 @@ typedef struct x_watcher {
 
 				XWATCHER_FILE_EVENT send_event = XWATCHER_FILE_NONE;
 
-				if(event->mask & IN_CREATE)
-					send_event = XWATCHER_FILE_CREATED;
 				if(event->mask & IN_CLOSE_WRITE)
 					send_event = XWATCHER_FILE_MODIFIED;
 				if(event->mask & IN_DELETE_SELF)
 					send_event = XWATCHER_FILE_REMOVED;
 				if(event->mask & IN_MOVE_SELF)
 					send_event = XWATCHER_FILE_MOVED;
-				if(event->mask & IN_DELETE)
-					send_event = XWATCHER_DIRECTORY_CONTENT_REMOVED;
-				if(event->mask & IN_MOVED)
-					send_event = XWATCHER_DIRECTORY_CONTENT_MOVED;
 				if(event->mask & IN_ATTRIB)
 					send_event = XWATCHER_FILE_ATTRIBUTES_CHANGED;
 				if(event->mask & IN_OPEN)
 					send_event = XWATCHER_FILE_OPENED;
+				if(event->mask & IN_CREATE)
+					send_event = XWATCHER_DIRECTORY_CONTENT_CRETAED;
+				if(event->mask & IN_DELETE)
+					send_event = XWATCHER_DIRECTORY_CONTENT_REMOVED;
+				if(event->mask & IN_MOVED)
+					send_event = XWATCHER_DIRECTORY_CONTENT_MOVED;
 
 				// file found(?)
 				if(file != NULL) {

--- a/include/x-watcher/x-watcher.h
+++ b/include/x-watcher/x-watcher.h
@@ -20,10 +20,14 @@ typedef enum event {
 	XWATCHER_FILE_CREATED,
 	XWATCHER_FILE_MODIFIED,
 	XWATCHER_FILE_OPENED,
+	XWATCHER_FILE_MOVED,
 	XWATCHER_FILE_ATTRIBUTES_CHANGED,
 	XWATCHER_FILE_NONE,
 	XWATCHER_FILE_RENAMED,
-	// probs more but i couldn't care much
+
+	// directory specific events
+	XWATCHER_DIRECTORY_CONTENT_REMOVED,
+	XWATCHER_DIRECTORY_CONTENT_MOVED,
 } XWATCHER_FILE_EVENT;
 
 typedef struct xWatcher_reference {
@@ -178,6 +182,12 @@ typedef struct x_watcher {
 					send_event = XWATCHER_FILE_MODIFIED;
 				if(event->mask & IN_DELETE_SELF)
 					send_event = XWATCHER_FILE_REMOVED;
+				if(event->mask & IN_MOVE_SELF)
+					send_event = XWATCHER_FILE_MOVED;
+				if(event->mask & IN_DELETE)
+					send_event = XWATCHER_DIRECTORY_CONTENT_REMOVED;
+				if(event->mask & IN_MOVED)
+					send_event = XWATCHER_DIRECTORY_CONTENT_MOVED;
 				if(event->mask & IN_ATTRIB)
 					send_event = XWATCHER_FILE_ATTRIBUTES_CHANGED;
 				if(event->mask & IN_OPEN)


### PR DESCRIPTION
[1] Previously, `IN_CLOSE_WRITE` and `IN_CLOSE_NOWRITE` was represented as `XWATCHER_FILE_REMOVED` which are completely wrong. According to the man page these events indicate that a file was closed (after being opened for writing or reading respectively), not that it was removed.

[2] Fix a race condition on `XWATCHER_FILE_MODIFIED` event where the watcher process immediately read the file when the writing process are not done yet, causing ENOENT error due inode change within write process. Use `IN_CLOSE_WRITE` to represent `XWATCHER_FILE_MODIFIED` instead as it triggered after the file closed for writing.

[3] Use `IN_DELETE_SELF` to represent `XWATCHER_FILE_REMOVED` as it tells when the watched file/dir itself was removed, not the file/dir inside the watched directory. More accurate representation of `XWATCHER_FILE_REMOVED` description in `README.md`.