### PR TITLE
Fix inotify event typo

### DIFF
--- a/include/x-watcher/x-watcher.h
+++ b/include/x-watcher/x-watcher.h
@@ -191,7 +191,7 @@ typedef struct x_watcher {
 					send_event = XWATCHER_DIRECTORY_CONTENT_CRETAED;
 				if(event->mask & IN_DELETE)
 					send_event = XWATCHER_DIRECTORY_CONTENT_REMOVED;
-				if(event->mask & IN_MOVED)
+				if(event->mask & IN_MOVE)
 					send_event = XWATCHER_DIRECTORY_CONTENT_MOVED;
 
 				// file found(?)


### PR DESCRIPTION
It should be `IN_MOVE`, my bad.

https://man7.org/linux/man-pages/man7/inotify.7.html